### PR TITLE
Print current selections, or entire file if not selected. Also, allow different colour schemes

### DIFF
--- a/Print to HTML.sublime-settings
+++ b/Print to HTML.sublime-settings
@@ -37,6 +37,10 @@
     // If true, draw a light grey background behind code (probably not ideal for printing)
     "draw_background": false,
 
+    // Style to use when formatting text
+    // Avaliable styles can be found under <Package Folder>/pygments/styles
+    "style": "default",
+
     // Use this to add custom CSS rules to the output; note that using "monochrome": true may
     // override color-related custom CSS styling used here
     // "custom_css": "body { background-color: black; } .highlight * { color: white; }"

--- a/PrintToHTML.py
+++ b/PrintToHTML.py
@@ -26,7 +26,13 @@ class PrintToHtmlCommand(sublime_plugin.TextCommand):
             for selection in selections:
                 # start/end at start/end of selected line
                 region = self.view.line(sublime.Region(selection.a, selection.b))
-                texts.append([self.view.rowcol(region.a)[0] + 1, self.view.substr(region)])
+
+                # check for previous selection's bounds, add together if they overlap
+                if len(texts) > 0 and (texts[-1][2].b >= region.a):
+                    new_region = sublime.Region(texts[-1][2].a, region.b)
+                    texts[-1] = [texts[-1][0], self.view.substr(new_region), new_region]
+                else:
+                    texts.append([self.view.rowcol(region.a)[0] + 1, self.view.substr(region), region])
 
         else:
             region = sublime.Region(0, self.view.size())

--- a/PrintToHTML.py
+++ b/PrintToHTML.py
@@ -61,8 +61,11 @@ class PrintToHtmlCommand(sublime_plugin.TextCommand):
         optlist = ['line_numbering', 'draw_background', 'line_anchors']
         options = dict(map(lambda x: (x, settings.get(x, False)), optlist))
 
+        # style
+        style = settings.get('style', 'default')
+
         # perform the conversion to HTML
-        css, texts = convert_to_html(filename, texts, syntax, encoding, options)
+        css, texts = convert_to_html(filename, texts, syntax, encoding, options, style)
 
         # construct onload body attrib for print/close JS within browser
         if target == 'browser':
@@ -195,13 +198,14 @@ def get_lexer(filename, syntax, text):
     return lexer
 
 
-def convert_to_html(filename, texts, syntax, encoding, options):
+def convert_to_html(filename, texts, syntax, encoding, options, style):
     """Convert text to HTML form, using filename and syntax as lexer hints."""
     formatter = pygments.formatters.HtmlFormatter(
         encoding=encoding,
         linenos='inline' if options['line_numbering'] else False,
         nobackground=not options['draw_background'],
-        lineanchors='line' if options['line_anchors'] else False)
+        lineanchors='line' if options['line_anchors'] else False,
+        style=style)
 
     css = formatter.get_style_defs('.highlight')
     texts_out = []

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ If you prefer to install manually, install git, then:
 
  * Use ST2's internal scope and color data from a buffer to produce an exact replica of a file from ST2 in HTML form. The current approach using Pygments has limitations regarding formats unknown by Pygments (e.g. Markdown) and documents with mixed syntaxes (e.g. PHP embedded in HTML).
  * Support different color schemes.
- * Only print current selection(s) OR print selected text with a highlighted background.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ If you prefer to install manually, install git, then:
 ## Future goals
 
  * Use ST2's internal scope and color data from a buffer to produce an exact replica of a file from ST2 in HTML form. The current approach using Pygments has limitations regarding formats unknown by Pygments (e.g. Markdown) and documents with mixed syntaxes (e.g. PHP embedded in HTML).
- * Support different color schemes.
 
 ## Credits
 

--- a/pygments/styles/__init__.py
+++ b/pygments/styles/__init__.py
@@ -15,7 +15,25 @@ from pygments.util import ClassNotFound
 ## HACK: We must import this here otherwise ST2 will fail to find it, because
 ## normally Pygments imports them only on-demand and therefore ST2 thinks they
 ## don't really exist
+import pygments.styles.murphy
+import pygments.styles.emacs
+import pygments.styles.friendly
+import pygments.styles.vs
+import pygments.styles.native
+import pygments.styles.bw
+import pygments.styles.fruity
+import pygments.styles.manni
+import pygments.styles.perldoc
+import pygments.styles.borland
+import pygments.styles.tango
+import pygments.styles.pastie
+import pygments.styles.rrt
+import pygments.styles.trac
+import pygments.styles.monokai
 import pygments.styles.default
+import pygments.styles.autumn
+import pygments.styles.colorful
+import pygments.styles.vim
 
 #: Maps style names to 'submodule::classname'.
 STYLE_MAP = {


### PR DESCRIPTION
Just a little changing stuff around to let people select regions to print, instead of the entire file. Allows people to print multiple regions at the same time, and they'll appear underneath each other.

I also removed the convert_with_pygments function, as I don't think it's useful to us with these changes.

I also added a simple style setting, that defines which pygments style to use when laying out text. Not sure if I should put it into another Pull Request somehow, it kinda just added it to this one instead.
